### PR TITLE
fix: duplicate Dzone section

### DIFF
--- a/presentation.html
+++ b/presentation.html
@@ -63,18 +63,7 @@ layout: reveal
 			</ul>
 		</p>
 	</section>
-  <section id="dzone">
-		<h2>DZone</h2>
-		<p>
-			<ul>
-				<li>Links curation</li>
-				<li>Dedicated "Zones" for a lot of technology (Java "Zone" = Javalobby)</li>
-				<li><a href="http://www.dzone.com/">Website</a></li>
-			</ul>
-		</p>
-		<p><small>Press <strong><a href="#" class="navigate-down">↓</a></strong> to continue</small></p>
-	</section>
-  <section id="hackernews">
+    <section id="hackernews">
     <h2>hackernews</h2>
     <p>
       <ul>
@@ -84,7 +73,7 @@ layout: reveal
       </ul>
     </p>
     <p><small>Press <strong><a href="#" class="navigate-down">↓</a></strong> to continue</small></p>
-  </section>
+    </section>
 </section>
 
 <section>


### PR DESCRIPTION
Remove duplicate "Dzone" section from the "General Websites" section.